### PR TITLE
fix: enhance tilde operator validation and usage rules and align better with bw api on tildes

### DIFF
--- a/src/validation/engine.rs
+++ b/src/validation/engine.rs
@@ -27,6 +27,7 @@ impl ValidationEngine {
                 Box::new(MixedNearRule),
                 Box::new(PureNegativeRule),
                 Box::new(BinaryOperatorRule),
+                Box::new(TildeUsageRule),
                 // performance validation rules
                 Box::new(WildcardPerformanceRule),
                 Box::new(ShortTermRule),


### PR DESCRIPTION
- stricter validation for the tilde operator in the lexer and parser (must be immediately followed by a distance number, no spaces)
- fix issue where `"term1 term2"~5 AND term3` was throwing error related to the mixing of NEAR and AND
- add warnings for when used with single terms or quoted words.